### PR TITLE
feat(autouse): auto-use skeleton if there is only one for given filetype

### DIFF
--- a/lua/esqueleto/init.lua
+++ b/lua/esqueleto/init.lua
@@ -17,6 +17,12 @@ M.write = function (file)
   vim.cmd("0r " .. file)
 end
 
+M._write_file_safe = function (file)
+    if file ~= nil then
+        M.write(file)
+    end
+end
+
 -- Template selector
 -- TODO: Add description
 M.select = function(templates)
@@ -28,14 +34,18 @@ M.select = function(templates)
   local selection = nil
   local templatenames = vim.tbl_keys(templates)
   table.sort(templatenames, function(a, b) return a:lower() < b:lower() end)
+
+  -- if only one template, write and return early
+  if #templatenames == 1 then
+      M._write_file_safe(templates[templatenames[1]])
+      return
+  end
+
   vim.ui.select(
     templatenames,
     { prompt = 'Select skeleton to use:', },
-    function(choice) 
-      local file = templates[choice]
-      if  file ~= nil then
-        M.write(file)
-      end
+    function(choice)
+      M._write_file_safe(templates[choice])
     end
   )
 end


### PR DESCRIPTION
If there's only one skeleton found for a given filetype, bypass the selection dialog and automatically use that template.

Let me know if I've done anything wrong with the preferred format for this PR. Thanks for writing this plugin!