### PR TITLE
Provide option to ignore certain files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ require("esqueleto").setup(
 
       advanced = {
         -- List of files glob patterns to ignore
+        -- Or alternatively, a function that determines if a file should be ignored
         ignored = {},
 
         -- Ignore OS files like .DS_Store

--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ require("esqueleto").setup(
       patterns = { "README.md", "python" },
 
       -- whether to auto-use a template if it's the only one for a pattern
-      autouse = true
+      autouse = true,
+
+      advanced = {
+        -- List of files glob patterns to ignore
+        ignored = {},
+
+        -- Ignore OS files like .DS_Store
+        -- Exhaustive list: https://www.toptal.com/developers/gitignore/api/windows,macos,linux
+        ignore_os_files = true,
+      },
     }
 )
 ```
@@ -63,7 +72,11 @@ The default options of `esqueleto` are
     {
       directories = { vim.fn.stdpath("config") .. "/skeletons" },
       patterns = { },
-      autouse = true
+      autouse = true,
+      advanced = {
+        ignored = {},
+        ignore_os_files = true,
+      }
     }
 ~~~
 

--- a/doc/esqueleto.txt
+++ b/doc/esqueleto.txt
@@ -54,6 +54,12 @@ First, |esqueleto| setup in the `init.lua` file is as follows: >
               -- File type
               'python',
           },
+
+          -- Advanced options
+          advanced = {
+              ignore_os_files = true,
+              ignore = {}
+          },
     })
 <
 Second (and based in the setup showcased above), the following step involves
@@ -119,6 +125,7 @@ setup({patterns}, {directory})
             {
                 directories = {vim.fn.stdpath("config") .. "/skeletons"},
                 patterns = { },
+                advanced = { ignore = {}, ignore_os_files = true },
             }
         )
 <
@@ -127,6 +134,15 @@ setup({patterns}, {directory})
       • {patterns}  (table) File names or patterns to match
       • {directory} (string) An absolute or relative path to the directory
                     with templates.
+      • {advanced}  (table) Advanced options, including:
+                    • {ignore}          (table|function) List of glob patterns of
+                                        files to be ignored; alternatively, a
+                                        predicate that determines if a file
+                                        should be ignored, given its full filepath.
+                    • {ignore_os_files} (boolean) Whether to ignore OS files,
+                                        such as `.DS_Store`, `Desktop.ini`.
+                                        For an exhaustive list, see
+                                        `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
 
 ==============================================================================
                                                                  *ex-commands*

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -4,7 +4,6 @@ M.default_config = {
   autouse = true,
   directories = { vim.fn.stdpath("config") .. "/skeletons" },
   patterns = {},
-  ignore = function (f) return vim.fn.fnamemodify(f, ':t') == '.DS_Store' end,
 }
 
 M.updateconfig = function(config)
@@ -16,7 +15,6 @@ M.updateconfig = function(config)
     autouse = { config.autouse, 'boolean' },
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
-    ignore = { config.ignore, 'function' },
   })
 
   return config

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -18,7 +18,7 @@ M.updateconfig = function(config)
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
     use_os_ignore = { config.use_os_ignore, 'boolean' },
-    extra_ignore = { config.ignore, { 'table', 'function' } },
+    extra_ignore = { config.extra_ignore, { 'table', 'function' } },
   })
 
   return config

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -4,7 +4,8 @@ M.default_config = {
   autouse = true,
   directories = { vim.fn.stdpath("config") .. "/skeletons" },
   patterns = {},
-  ignore = function (f) return vim.fn.fnamemodify(f, ':t') == '.DS_Store' end,
+  use_os_ignore = true,
+  extra_ignore = {},
 }
 
 M.updateconfig = function(config)
@@ -16,7 +17,8 @@ M.updateconfig = function(config)
     autouse = { config.autouse, 'boolean' },
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
-    ignore = { config.ignore, 'function' },
+    use_os_ignore = { config.use_os_ignore, 'boolean' },
+    extra_ignore = { config.ignore, { 'table', 'function' } },
   })
 
   return config

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -4,6 +4,7 @@ M.default_config = {
   autouse = true,
   directories = { vim.fn.stdpath("config") .. "/skeletons" },
   patterns = {},
+  ignore = function (f) return vim.fn.fnamemodify(f, ':t') == '.DS_Store' end,
 }
 
 M.updateconfig = function(config)
@@ -15,6 +16,7 @@ M.updateconfig = function(config)
     autouse = { config.autouse, 'boolean' },
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
+    ignore = { config.ignore, 'function' },
   })
 
   return config

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -4,8 +4,10 @@ M.default_config = {
   autouse = true,
   directories = { vim.fn.stdpath("config") .. "/skeletons" },
   patterns = {},
-  use_os_ignore = true,
-  extra_ignore = {},
+  advanced = {
+    ignored = {},
+    ignore_os_files = true,
+  }
 }
 
 M.updateconfig = function(config)
@@ -17,8 +19,9 @@ M.updateconfig = function(config)
     autouse = { config.autouse, 'boolean' },
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
-    use_os_ignore = { config.use_os_ignore, 'boolean' },
-    extra_ignore = { config.extra_ignore, { 'table', 'function' } },
+    advanced = { config.advanced, 'table' },
+    ["advanced.ignored"] = { config.advanced.ignored, { 'table', 'function' } },
+    ["advanced.ignore_os_files"] = { config.advanced.ignore_os_files, 'boolean' },
   })
 
   return config

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -4,7 +4,8 @@ M.default_config = {
   autouse = true,
   directories = { vim.fn.stdpath("config") .. "/skeletons" },
   patterns = {},
-  ignore = function (f) return vim.fn.fnamemodify(f, ':t') == '.DS_Store' end,
+  use_os_ignore = true,
+  extra_ignore = {},
 }
 
 M.updateconfig = function(config)
@@ -16,7 +17,8 @@ M.updateconfig = function(config)
     autouse = { config.autouse, 'boolean' },
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
-    ignore = { config.ignore, 'function' },
+    use_os_ignore = { config.use_os_ignore, 'boolean' },
+    extra_ignore = { config.extra_ignore, { 'table', 'function' } },
   })
 
   return config

--- a/lua/esqueleto/config.lua
+++ b/lua/esqueleto/config.lua
@@ -4,15 +4,10 @@ M.default_config = {
   autouse = true,
   directories = { vim.fn.stdpath("config") .. "/skeletons" },
   patterns = {},
-<<<<<<< HEAD
-  use_os_ignore = true,
-  extra_ignore = {},
-=======
   advanced = {
     ignored = {},
     ignore_os_files = true,
   }
->>>>>>> origin/main
 }
 
 M.updateconfig = function(config)
@@ -24,14 +19,9 @@ M.updateconfig = function(config)
     autouse = { config.autouse, 'boolean' },
     directories = { config.directories, 'table' },
     patterns = { config.patterns, 'table' },
-<<<<<<< HEAD
-    use_os_ignore = { config.use_os_ignore, 'boolean' },
-    extra_ignore = { config.extra_ignore, { 'table', 'function' } },
-=======
     advanced = { config.advanced, 'table' },
     ["advanced.ignored"] = { config.advanced.ignored, { 'table', 'function' } },
     ["advanced.ignore_os_files"] = { config.advanced.ignore_os_files, 'boolean' },
->>>>>>> origin/main
   })
 
   return config

--- a/lua/esqueleto/constants.lua
+++ b/lua/esqueleto/constants.lua
@@ -2,6 +2,6 @@ local M = {}
 
 -- OS-specific ignoring files, from `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
 -- Index: Thu Sep 28 20:45:56 BST 2023
-M.ignored_files = { '*~', '.fuse_hidden*', '.directory', '.Trash-*', '.nfs*', '.DS_Store', '.AppleDouble', '.LSOverride', 'Icon', '._*', '.DocumentRevisions-V100', '.fseventsd', '.Spotlight-V100', '.TemporaryItems', '.Trashes', '.VolumeIcon.icns', '.com.apple.timemachine.donotpresent', '.AppleDB', '.AppleDesktop', 'Network Trash Folder', 'Temporary Items', '.apdisk', '*.icloud', 'Thumbs.db', 'Thumbs.db:encryptable', 'ehthumbs.db', 'ehthumbs_vista.db', '*.stackdump', '[Dd]esktop.ini', '$RECYCLE.BIN/', '*.cab', '*.msi', '*.msix', '*.msm', '*.msp', '*.lnk' }
+M.ignored_patterns = { '*~', '.fuse_hidden*', '.directory', '.Trash-*', '.nfs*', '.DS_Store', '.AppleDouble', '.LSOverride', 'Icon', '._*', '.DocumentRevisions-V100', '.fseventsd', '.Spotlight-V100', '.TemporaryItems', '.Trashes', '.VolumeIcon.icns', '.com.apple.timemachine.donotpresent', '.AppleDB', '.AppleDesktop', 'Network Trash Folder', 'Temporary Items', '.apdisk', '*.icloud', 'Thumbs.db', 'Thumbs.db:encryptable', 'ehthumbs.db', 'ehthumbs_vista.db', '*.stackdump', '[Dd]esktop.ini', '$RECYCLE.BIN/', '*.cab', '*.msi', '*.msix', '*.msm', '*.msp', '*.lnk' }
 
 return M

--- a/lua/esqueleto/constants.lua
+++ b/lua/esqueleto/constants.lua
@@ -1,7 +1,45 @@
 local M = {}
 
--- OS-specific ignoring files, from `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
+-- OS-specific ignoring files, obtained from gitignore.io
+-- `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
 -- Index: Thu Sep 28 20:45:56 BST 2023
-M.ignored_patterns = { '*~', '.fuse_hidden*', '.directory', '.Trash-*', '.nfs*', '.DS_Store', '.AppleDouble', '.LSOverride', 'Icon', '._*', '.DocumentRevisions-V100', '.fseventsd', '.Spotlight-V100', '.TemporaryItems', '.Trashes', '.VolumeIcon.icns', '.com.apple.timemachine.donotpresent', '.AppleDB', '.AppleDesktop', 'Network Trash Folder', 'Temporary Items', '.apdisk', '*.icloud', 'Thumbs.db', 'Thumbs.db:encryptable', 'ehthumbs.db', 'ehthumbs_vista.db', '*.stackdump', '[Dd]esktop.ini', '$RECYCLE.BIN/', '*.cab', '*.msi', '*.msix', '*.msm', '*.msp', '*.lnk' }
+M.ignored_os_patterns = {
+	"*~",
+	".fuse_hidden*",
+	".directory",
+	".Trash-*",
+	".nfs*",
+	".DS_Store",
+	".AppleDouble",
+	".LSOverride",
+	"Icon",
+	"._*",
+	".DocumentRevisions-V100",
+	".fseventsd",
+	".Spotlight-V100",
+	".TemporaryItems",
+	".Trashes",
+	".VolumeIcon.icns",
+	".com.apple.timemachine.donotpresent",
+	".AppleDB",
+	".AppleDesktop",
+	"Network Trash Folder",
+	"Temporary Items",
+	".apdisk",
+	"*.icloud",
+	"Thumbs.db",
+	"Thumbs.db:encryptable",
+	"ehthumbs.db",
+	"ehthumbs_vista.db",
+	"*.stackdump",
+	"[Dd]esktop.ini",
+	"$RECYCLE.BIN/",
+	"*.cab",
+	"*.msi",
+	"*.msix",
+	"*.msm",
+	"*.msp",
+	"*.lnk",
+}
 
 return M

--- a/lua/esqueleto/constants.lua
+++ b/lua/esqueleto/constants.lua
@@ -1,10 +1,5 @@
 local M = {}
 
-<<<<<<< HEAD
--- OS-specific ignoring files, from `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
--- Index: Thu Sep 28 20:45:56 BST 2023
-M.ignored_patterns = { '*~', '.fuse_hidden*', '.directory', '.Trash-*', '.nfs*', '.DS_Store', '.AppleDouble', '.LSOverride', 'Icon', '._*', '.DocumentRevisions-V100', '.fseventsd', '.Spotlight-V100', '.TemporaryItems', '.Trashes', '.VolumeIcon.icns', '.com.apple.timemachine.donotpresent', '.AppleDB', '.AppleDesktop', 'Network Trash Folder', 'Temporary Items', '.apdisk', '*.icloud', 'Thumbs.db', 'Thumbs.db:encryptable', 'ehthumbs.db', 'ehthumbs_vista.db', '*.stackdump', '[Dd]esktop.ini', '$RECYCLE.BIN/', '*.cab', '*.msi', '*.msix', '*.msm', '*.msp', '*.lnk' }
-=======
 -- OS-specific ignoring files, obtained from gitignore.io
 -- `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
 -- Index: Thu Sep 28 20:45:56 BST 2023
@@ -46,6 +41,5 @@ M.ignored_os_patterns = {
 	"*.msp",
 	"*.lnk",
 }
->>>>>>> origin/main
 
 return M

--- a/lua/esqueleto/constants.lua
+++ b/lua/esqueleto/constants.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+-- OS-specific ignoring files, from `https://www.toptal.com/developers/gitignore/api/windows,macos,linux`
+-- Index: Thu Sep 28 20:45:56 BST 2023
+M.ignored_files = { '*~', '.fuse_hidden*', '.directory', '.Trash-*', '.nfs*', '.DS_Store', '.AppleDouble', '.LSOverride', 'Icon', '._*', '.DocumentRevisions-V100', '.fseventsd', '.Spotlight-V100', '.TemporaryItems', '.Trashes', '.VolumeIcon.icns', '.com.apple.timemachine.donotpresent', '.AppleDB', '.AppleDesktop', 'Network Trash Folder', 'Temporary Items', '.apdisk', '*.icloud', 'Thumbs.db', 'Thumbs.db:encryptable', 'ehthumbs.db', 'ehthumbs_vista.db', '*.stackdump', '[Dd]esktop.ini', '$RECYCLE.BIN/', '*.cab', '*.msi', '*.msix', '*.msm', '*.msp', '*.lnk' }
+
+return M

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -8,11 +8,7 @@ M.writetemplate = function(file)
   end
 end
 
-M.isignored = function (ignore, filepath)
-  return ignore(filepath)
-end
-
-M.gettemplates = function(pattern, alldirectories, ignore)
+M.gettemplates = function(pattern, alldirectories)
   local templates = {}
 
   -- Count directories that contain templates for pattern
@@ -29,12 +25,10 @@ M.gettemplates = function(pattern, alldirectories, ignore)
       for filepath in vim.fs.dir(directory .. pattern .. '/') do
         filepath = directory .. pattern .. "/" .. filepath
         local name = vim.fs.basename(filepath)
-        if not M.isignored(ignore, name) then
-          if ndirs > 1 then
-            name = vim.fn.simplify(directory) .. " :: " .. name
-          end
-          templates[name] = filepath
+        if ndirs > 1 then
+          name = vim.fn.simplify(directory) .. " :: " .. name
         end
+        templates[name] = filepath
       end
     end
   end
@@ -89,7 +83,7 @@ M.inserttemplate = function(opts)
     end
 
     -- Get templates for selected pattern
-    local templates = M.gettemplates(pattern, opts.directories, opts.ignore)
+    local templates = M.gettemplates(pattern, opts.directories)
 
     -- Pop-up selection UI
     M.selecttemplate(templates, opts)

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -8,7 +8,11 @@ M.writetemplate = function(file)
   end
 end
 
-M.gettemplates = function(pattern, alldirectories)
+M.isignored = function (ignore, filepath)
+  return ignore(filepath)
+end
+
+M.gettemplates = function(pattern, alldirectories, ignore)
   local templates = {}
 
   -- Count directories that contain templates for pattern
@@ -25,10 +29,12 @@ M.gettemplates = function(pattern, alldirectories)
       for filepath in vim.fs.dir(directory .. pattern .. '/') do
         filepath = directory .. pattern .. "/" .. filepath
         local name = vim.fs.basename(filepath)
-        if ndirs > 1 then
-          name = vim.fn.simplify(directory) .. " :: " .. name
+        if not M.isignored(ignore, name) then
+          if ndirs > 1 then
+            name = vim.fn.simplify(directory) .. " :: " .. name
+          end
+          templates[name] = filepath
         end
-        templates[name] = filepath
       end
     end
   end
@@ -83,7 +89,7 @@ M.inserttemplate = function(opts)
     end
 
     -- Get templates for selected pattern
-    local templates = M.gettemplates(pattern, opts.directories)
+    local templates = M.gettemplates(pattern, opts.directories, opts.ignore)
 
     -- Pop-up selection UI
     M.selecttemplate(templates, opts)

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -47,9 +47,10 @@ local any = function (f, t)
 end
 
 -- Determine if a file matches a gitignore glob pattern
--- TODO
+-- by converting to regex, then vim.regex API.
 local match_gitignore = function (filepath, gitignore_pattern)
-  error 'TODO'
+  local regpat = vim.fn.glob2regpat(gitignore_pattern)  -- ^$ automatically added
+  return vim.regex(regpat):match_str(filepath) ~= nil
 end
 
 -- Determine if a file should be ignored,

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -73,68 +73,6 @@ M.gettemplates = function(pattern, opts)
   return templates
 end
 
--- List ignored files under a directory, given a list of glob patterns
-local listignored = function(dir, ignored_pats)
-  return vim.tbl_flatten(vim.tbl_map(function(pat)
-    return vim.fn.globpath(dir, pat, true, true, true)
-  end, ignored_pats))
-end
-
--- Returns a ignore checker
-local getignorechecker = function(opts)
-  local os_ignore_pats = opts.use_os_ignore and require('esqueleto.constants').ignored_patterns or {}
-  local extra = opts.extra_ignore
-  local extra_ignore_pats, extra_ignore_func = (function()
-    if type(extra) == 'function' then
-      return {}, extra
-    else
-      assert(type(extra) == 'table')
-      return extra, function(_) return false end
-    end
-  end)()
-
-  return function(filepath)
-    local dir = vim.fn.fnamemodify(filepath, ':p:h')
-    return extra_ignore_func(dir) or vim.tbl_contains(listignored(dir, os_ignore_pats), filepath)
-      or vim.tbl_contains(listignored(dir, extra_ignore_pats), filepath)
-  end
-end
-
-M.getunignoredtemplates = function(pattern, opts)
-  local templates = {}
-  local isignored = getignorechecker(opts)
-
-  local alldirectories = vim.tbl_map(function(f)
-    return vim.fn.fnamemodify(f, ':p')
-  end, opts.directories)
-
-  -- Count directories that contain templates for pattern
-  local ndirs = 0
-  for _, directory in pairs(alldirectories) do
-    ndirs = ndirs + vim.fn.isdirectory(directory .. pattern .. '/')
-  end
-
-  -- Get templates for pattern
-  for _, directory in ipairs(alldirectories) do
-    local pattern_dir = directory .. pattern .. '/'
-    local exists_dir = vim.fn.isdirectory(pattern_dir) == 1
-    if exists_dir then
-      for basename in vim.fs.dir(pattern_dir) do
-        local filepath = vim.fs.normalize(pattern_dir .. basename)
-        if not isignored(filepath) then
-          local name = vim.fs.basename(filepath)
-          if ndirs > 1 then
-            name = vim.fn.simplify(directory) .. " :: " .. name
-          end
-          templates[name] = filepath
-        end
-      end
-    end
-  end
-
-  return templates
-end
-
 M.selecttemplate = function(templates, opts)
   -- Check if templates exist
   if vim.tbl_isempty(templates) then
@@ -182,11 +120,7 @@ M.inserttemplate = function(opts)
     end
 
     -- Get templates for selected pattern
-<<<<<<< HEAD
-    local templates = M.getunignoredtemplates(pattern, opts)
-=======
     local templates = M.gettemplates(pattern, opts)
->>>>>>> origin/main
 
     -- Pop-up selection UI
     M.selecttemplate(templates, opts)

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -2,10 +2,6 @@ local M = {}
 
 _G.esqueleto_inserted = {}
 
-M.isignored = function(ignore, filepath)
-    return ignore(filepath)
-end
-
 M.writetemplate = function(file)
   if file ~= nil then
     vim.cmd("0r " .. file)
@@ -40,8 +36,48 @@ M.gettemplates = function(pattern, alldirectories)
   return templates
 end
 
-M.getunignoredtemplates = function(pattern, alldirectories, ignore)
+local any = function (f, t)
+  for _, e in pairs(t) do
+    if f(e) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Determine if a file matches a gitignore glob pattern
+-- by converting to regex, then vim.regex API.
+local match_gitignore = function (filepath, gitignore_pattern)
+  local regpat = vim.fn.glob2regpat(gitignore_pattern)  -- ^$ automatically added
+  return vim.regex(regpat):match_str(filepath) ~= nil
+end
+
+-- Determine if a file should be ignored,
+-- according to user's choice
+local isignored = function (filepath, extra_ignore, use_os_ignore)
+  local is_user_ignored = (function ()
+    if type(extra_ignore) == 'function' then
+      return extra_ignore(filepath)
+    else
+      return any(function (pat) return match_gitignore(filepath, pat) end, extra_ignore)
+    end
+  end)()
+
+  local is_os_ignored = (function ()
+    if not use_os_ignore then return false end
+    local os_ignore = require('esqueleto.constants').ignored_files
+    return any(function (pat) return match_gitignore(filepath, pat) end, os_ignore)
+  end)()
+
+  return is_user_ignored or is_os_ignored
+end
+
+M.getunignoredtemplates = function(pattern, opts)
   local templates = {}
+  local alldirectories = opts.directories
+  local extra_ignore = opts.extra_ignore
+  local use_os_ignore = opts.use_os_ignore
 
   -- Count directories that contain templates for pattern
   local ndirs = 0
@@ -56,7 +92,8 @@ M.getunignoredtemplates = function(pattern, alldirectories, ignore)
     if vim.fn.isdirectory(directory .. pattern .. '/') == 1 then
       for filepath in vim.fs.dir(directory .. pattern .. '/') do
         filepath = directory .. pattern .. "/" .. filepath
-        if not M.isignored(ignore, filepath) then
+        local ignored = isignored(filepath, extra_ignore, use_os_ignore)
+        if not ignored then
           local name = vim.fs.basename(filepath)
           if ndirs > 1 then
             name = vim.fn.simplify(directory) .. " :: " .. name
@@ -117,7 +154,7 @@ M.inserttemplate = function(opts)
     end
 
     -- Get templates for selected pattern
-    local templates = M.getunignoredtemplates(pattern, opts.directories, opts.ignore)
+    local templates = M.getunignoredtemplates(pattern, opts)
 
     -- Pop-up selection UI
     M.selecttemplate(templates, opts)

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -49,8 +49,15 @@ end
 -- Determine if a file matches a gitignore glob pattern
 -- by converting to regex, then vim.regex API.
 local match_gitignore = function (filepath, gitignore_pattern)
-  local regpat = vim.fn.glob2regpat(gitignore_pattern)  -- ^$ automatically added
-  return vim.regex(regpat):match_str(filepath) ~= nil
+  local regpat = vim.fn.glob2regpat(gitignore_pattern):sub(2)  -- manually remove ^; hackish
+  local start, finish = vim.regex(regpat):match_str(filepath)
+  local res = (function ()
+    if start == nil or finish == nil then return false end
+    if start == finish then return false end  -- empty match, won't do
+    return finish == #filepath
+  end)()
+
+  return res
 end
 
 -- Determine if a file should be ignored,


### PR DESCRIPTION
Hi, thanks for the helpful plugin!

I believe it is necessary for certain files to not be picked up as templates. An infamous example is `.DS_Store`:

```
Select skeleton to use:
1: .DS_Store
2: default
```

To address this, I added a new option `ignore`, a function that, given the filepath, determines if a file should be ignored. Here's its default implementation:
```lua
ignore = function (f) return vim.fn.fnamemodify(f, ':t') == '.DS_Store' end
```

Please let me know if this looks good to you. :)