### PR TITLE
Improve the WYSIWYG-ness of skeletons

### DIFF
--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -67,7 +67,7 @@ M.writetemplate = function(file, opts)
     vim.api.nvim_win_set_cursor(0, cursor_pos)
   else
     -- If not, move the cursor to the last line
-    vim.cmd("norm G")
+    vim.cmd("norm! G")
   end
 end
 

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -35,23 +35,39 @@ end
 ---@param file string Template file path
 ---@param opts table Plugin configuration table
 M.writetemplate = function(file, opts)
-  if file ~= nil and not opts.wildcards.expand then
-    -- Place contents of template directly to buffer
-    vim.cmd("0r " .. file)
+  if file == nil then
+    -- Do an early return if no files are specified
+    return
+  end
+
+  local handler, message = io.open(file, "r")
+  if handler == nil then
+    -- Print error message and abort if no file handlers are created
+    vim.notify(message, vim.log.levels.ERROR)
+    return
+  end
+
+  -- Read the file
+  local content = handler:read("*a")
+
+  local lines, cursor_pos
+  if opts.wildcards.expand then
+    -- Place the contents of the file with the wildcards expanded
+    lines, cursor_pos = wildcards.parse(content, opts.wildcards.lookup)
+  else
+    -- ... or place them directly
+    lines = vim.split(content, "\n", { plain = true })
+  end
+
+  -- Replace the buffer with the given lines
+  vim.api.nvim_buf_set_lines(0, 0, -1, true, lines)
+
+  if cursor_pos ~= nil then
+    -- If a cursor wildcard was found, place the cursor there
+    vim.api.nvim_win_set_cursor(0, cursor_pos)
+  else
+    -- If not, move the cursor to the last line
     vim.cmd("norm G")
-  elseif file ~= nil and opts.wildcards.expand then
-    -- Expand wildcards from template and place contents in buffer
-    local content = io.open(file, "r"):read("*a")
-    local parsed_content, cursor_pos = wildcards.parse(content, opts.wildcards.lookup)
-    if content ~= nil then
-      vim.api.nvim_buf_set_lines(0, 0, -1, true, parsed_content)
-    end
-    -- If a cursor wildcard was found, place cursor there
-    if cursor_pos ~= nil then
-      vim.api.nvim_win_set_cursor(0, cursor_pos)
-    else
-      vim.cmd("norm G")
-    end
   end
 end
 

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -47,8 +47,8 @@ M.writetemplate = function(file, opts)
     return
   end
 
-  -- Read the file
-  local content = handler:read("*a")
+  -- Read the file and remove the new line at EOF
+  local content = handler:read("*a"):gsub("\n$", "")
 
   local lines, cursor_pos
   if opts.wildcards.expand then

--- a/lua/esqueleto/utils.lua
+++ b/lua/esqueleto/utils.lua
@@ -47,8 +47,8 @@ M.writetemplate = function(file, opts)
     return
   end
 
-  -- Read the file and remove the new line at EOF
-  local content = handler:read("*a"):gsub("\n$", "")
+  -- Read the file, convert EOL to LF and remove the new line at EOF
+  local content = handler:read("*a"):gsub("\r\n?", "\n"):gsub("\n$", "")
 
   local lines, cursor_pos
   if opts.wildcards.expand then


### PR DESCRIPTION
This PR will make the expanded skeletons look the same as the raw skeleton files by removing the new line at EOF that Neovim implicitly adds when writing files.

This PR includes two bonus commits: a fix for a bug where user key maps could cause unexpected behaviour, and support for skeletons with CR/CRLF line endings. Let me know if you want these as separate PRs; I will rebase them to a different branch.

## Screenshots

By using these skeletons:

![Test skeleton files](https://github.com/cvigilv/esqueleto.nvim/assets/72330683/707d753b-c05c-4e9f-ae4e-fc1b5b7aa52e)

### Original behaviour

![Original behaviour](https://github.com/cvigilv/esqueleto.nvim/assets/72330683/b3bd47a4-0de4-4763-95d8-7b905c59db42)


### This PR

![This PR](https://github.com/cvigilv/esqueleto.nvim/assets/72330683/d9c01c50-e72c-46ec-95a7-35dd4e84608d)
